### PR TITLE
Fix open_atomic directory bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Enjoy RSS feeds on newsboat with machine learning recommendations based on your 
 # Instructions:
 	1. Setup a virtual environment and install numpy and sklearn and sentence-transformers
 	2. in newsboat, use ctrl+e to set a flag and over the time, set the flag to s for those articles which pique your interest 
-	3. Once you have collected 200-300 articles suited to your interest, run python learn_preferences.py ~/.newsboat/cache.db (or any db file you use actively). This is a time consuming process if you have lots of articles in your database.
+       3. Once you have collected 200-300 articles suited to your interest, run python learn_preferences.py ~/.newsboat/cache.db (or any db file you use actively). This is a time consuming process if you have lots of articles in your database. The script will create a `models` directory for storing its output if it doesn't already exist.
 	4. In your newsboat URL file, set up a query feed to filter the flags 'cer'. In this filter, your recommended
 	   articles will pop up as unread.
 	5. Once this is done, you can run generate_recommendations.py ~/.newsboat/cache.db to update your database with the recommendations.

--- a/utils.py
+++ b/utils.py
@@ -48,6 +48,9 @@ def open_atomic(filepath, *args, **kwargs):
     """
     fsync = kwargs.pop('fsync', False)
 
+    # Ensure the target directory exists before creating the temporary file
+    os.makedirs(os.path.dirname(filepath), exist_ok=True)
+
     with _tempfile(dir=os.path.dirname(filepath)) as tmppath:
         with open(tmppath, *args, **kwargs) as f:
             yield f


### PR DESCRIPTION
## Summary
- ensure `utils.open_atomic` creates target directories
- document automatic model dir creation in README

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6850564dc46c83259297c5b62dda687f